### PR TITLE
#141 update dependencies

### DIFF
--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 17
+    - name: set up JDK 21
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: gradle
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,11 +161,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = JavaVersion.VERSION_21.toString()
         freeCompilerArgs += listOf(
             "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
             "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
@@ -269,7 +269,7 @@ dependencies {
 
     implementation(libs.appMetrica)
     implementation(libs.caoc)
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junitPlatformLauncher)
 }
 
 kover {

--- a/app/src/main/kotlin/ir/thatsmejavad/backgroundable/di/modules/NetworkModule.kt
+++ b/app/src/main/kotlin/ir/thatsmejavad/backgroundable/di/modules/NetworkModule.kt
@@ -3,7 +3,6 @@ package ir.thatsmejavad.backgroundable.di.modules
 import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import ir.thatsmejavad.backgroundable.BuildConfig
@@ -17,6 +16,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 accompanist = "0.34.0"
 activityCompose = "1.8.2"
-agp = "8.3.0"
+agp = "8.3.1"
 androidxJunit = "1.1.5"
 appMetrica = "5.3.0"
 appcompat = "1.6.1"
 caoc = "2.4.0"
 chucker = "4.0.0"
 coilCompose = "2.6.0"
-composeAnimation = "1.6.3"
-composeCompiler = "1.5.10"
-composeRuntime = "1.6.3"
-composeUi = "1.6.3"
-compsoeFoundation = "1.6.3"
+composeAnimation = "1.6.5"
+composeCompiler = "1.5.11"
+composeRuntime = "1.6.5"
+composeUi = "1.6.5"
+compsoeFoundation = "1.6.5"
 coreKtx = "1.12.0"
 coroutine = "1.8.0"
 dagger = "2.51"
@@ -23,10 +23,10 @@ jacoco = "0.8.11"
 javalite = "3.23.0"
 junit = "5.10.1"
 kotestAssertion = "5.8.0"
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 kotlinxSerialization = "1.6.3"
 kover = "0.7.4"
-ksp = "1.9.22-1.0.17"
+ksp = "1.9.23-1.0.20"
 ktlint = "1.2.1"
 ktlintGradle = "12.1.0"
 lifecycleRuntime = "2.7.0"
@@ -36,12 +36,11 @@ navigationCompose = "2.7.7"
 okhttp = "4.12.0"
 paging = "3.2.1"
 protobuf = "0.9.4"
-retrofit = "2.9.0"
-retrofitKotlinxSerializationConverter = "1.0.0"
+retrofit = "2.11.0"
 room = "2.6.1"
 splashscreen = "1.0.1"
-turbine = "1.0.0"
-zoomableImageCoil = "0.8.0"
+turbine = "1.1.0"
+zoomableImageCoil = "0.9.0"
 
 [libraries]
 accompanistNavigationMaterial = { module = "com.google.accompanist:accompanist-navigation-material", version.ref = "accompanist" }
@@ -72,6 +71,7 @@ datastore = { module = "androidx.datastore:datastore", version.ref = "datastore"
 datastorePreferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher" }
 kotestAssertion = { module = "io.kotest:kotest-assertions-core", version.ref = "kotestAssertion" }
 kotlinxSerialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 lifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntime" }
@@ -85,7 +85,7 @@ pagingCompose = { module = "androidx.paging:paging-compose", version.ref = "pagi
 pagingRuntimektx = { module = "androidx.paging:paging-runtime-ktx", version.ref = "paging" }
 protobufJavalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "javalite" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofitKotlinxSerializationConverter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
+retrofitKotlinxSerializationConverter = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 roomCompiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 roomKtx = { module = "androidx.room:room-ktx", version.ref = "room" }
 roomPaging = { module = "androidx.room:room-paging", version.ref = "room" }


### PR DESCRIPTION
- Bump java `17` to `21`
- agp from `8.3.2` to `8.3.1`
- compose Animation from `1.6.3` to `1.6.5`
- Compose Compiler from `1.5.10` to `1.5.11`
- Compose ui from `1.6.3` to `1.6.5`
- compose foundation from `1.6.3` to `1.6.5` kotlin from `1.9.22` from `1.9.23`
- ksp from `1.9.22-1.0.17` to `1.9.23-1.0.20`
- retrofit from `2.9.0` to `2.11.0`
 - turbine from `1.0.0` to `1.1.0`
 - telephoto from `0.8.0` to `0.9.0`